### PR TITLE
fix: do not loop if target host does not exist

### DIFF
--- a/pkg/bastion/ssh.go
+++ b/pkg/bastion/ssh.go
@@ -340,7 +340,7 @@ func PublicKeyAuthHandler(db *gorm.DB, logsLocation, aclCheckCmd, aesKey, dbDriv
 				host, err := dbmodels.HostByName(actx.db, actx.inputUsername)
 				if err != nil {
 					actx.err = err
-					return false
+					return true
 				}
 				_, err = bastionClientConfig(ctx, host)
 				if err != nil {


### PR DESCRIPTION
Introduced by 561e4822ae5416e7a6f9ae478169876027ede8bc, the current behavior prompts for password authentication when attempting to connect to an non-existent host, even though password authentication is not supported by "userTypeBastion".

This patch break the loop if target host does not exist

Before:
```
$ ssh localhost -p 2222 -l xxxx-non-existent
xxxx-non-existant@localhost's password:
```

After:
```
$ ssh localhost -p 2222 -l xxxx-non-existant
 no such target: xxxx-non-existant
```