### PR TITLE
fix: ttyrec/ttyplay header format

### DIFF
--- a/pkg/bastion/logchannel.go
+++ b/pkg/bastion/logchannel.go
@@ -24,7 +24,7 @@ func writeTTYRecHeader(fd io.Writer, length int) {
 	if err := binary.Write(fd, binary.LittleEndian, int32(tv.Sec)); err != nil {
 		log.Printf("failed to write log header: %v", err)
 	}
-	if err := binary.Write(fd, binary.LittleEndian, tv.Usec); err != nil {
+	if err := binary.Write(fd, binary.LittleEndian, int32(tv.Usec)); err != nil {
 		log.Printf("failed to write log header: %v", err)
 	}
 	if err := binary.Write(fd, binary.LittleEndian, int32(length)); err != nil {


### PR DESCRIPTION
Introducted by 9e331df78374e76ef3c95beff1893174804417cb

tv.Usec should be an int32 to respect ttyrec/ttyplay header format
