### PR TITLE
fix: performance issue and useless old data

### DIFF
--- a/pkg/bastion/dbinit.go
+++ b/pkg/bastion/dbinit.go
@@ -328,8 +328,8 @@ func DBInit(db *gorm.DB, aesKey string) error {
 					Status    string         `valid:"required"`
 					User      *dbmodels.User `gorm:"ForeignKey:UserID"`
 					Host      *dbmodels.Host `gorm:"ForeignKey:HostID"`
-					UserID    uint           `valid:"optional"`
-					HostID    uint           `valid:"optional"`
+					UserID    uint           `valid:"optional" gorm:"default:NULL"`
+					HostID    uint           `valid:"optional" gorm:"default:NULL"`
 					ErrMsg    string         `valid:"optional"`
 					Comment   string         `valid:"optional"`
 				}
@@ -344,7 +344,7 @@ func DBInit(db *gorm.DB, aesKey string) error {
 				type Event struct {
 					gorm.Model
 					Author   *dbmodels.User `gorm:"ForeignKey:AuthorID"`
-					AuthorID uint           `valid:"optional"`
+					AuthorID uint           `valid:"optional" gorm:"default:NULL"`
 					Domain   string         `valid:"required"`
 					Action   string         `valid:"required"`
 					Entity   string         `valid:"optional"`
@@ -424,8 +424,8 @@ func DBInit(db *gorm.DB, aesKey string) error {
 					Status    string         `valid:"required"`
 					User      *dbmodels.User `gorm:"ForeignKey:UserID"`
 					Host      *dbmodels.Host `gorm:"ForeignKey:HostID"`
-					UserID    uint           `valid:"optional"`
-					HostID    uint           `valid:"optional"`
+					UserID    uint           `valid:"optional" gorm:"default:NULL"`
+					HostID    uint           `valid:"optional" gorm:"default:NULL"`
 					ErrMsg    string         `valid:"optional"`
 					Comment   string         `valid:"optional"`
 				}
@@ -491,7 +491,7 @@ func DBInit(db *gorm.DB, aesKey string) error {
 					Groups   []*dbmodels.HostGroup `gorm:"many2many:host_host_groups;"`
 					Comment  string
 					Hop      *dbmodels.Host
-					HopID    uint
+					HopID    uint `gorm:"default:NULL"`
 				}
 				return tx.AutoMigrate(&Host{})
 			},
@@ -515,7 +515,7 @@ func DBInit(db *gorm.DB, aesKey string) error {
 					Comment  string
 					Hop      *dbmodels.Host
 					Logging  string
-					HopID    uint
+					HopID    uint `gorm:"default:NULL"`
 				}
 				return tx.AutoMigrate(&Host{})
 			},
@@ -541,6 +541,27 @@ func DBInit(db *gorm.DB, aesKey string) error {
 					Expiration  *time.Time
 				}
 				return tx.AutoMigrate(&ACL{})
+			},
+			Rollback: func(tx *gorm.DB) error { return fmt.Errorf("not implemented") },
+		}, {
+			ID: "33",
+			Migrate: func(tx *gorm.DB) error {
+				if err := migrateToGormV2(tx); err != nil {
+					return err
+				}
+
+				// Use AutoMigrate to recreate them with CASCADE enabled
+				return tx.AutoMigrate(
+					&dbmodels.SSHKey{},
+					&dbmodels.Host{},
+					&dbmodels.UserKey{},
+					&dbmodels.User{},
+					&dbmodels.UserGroup{},
+					&dbmodels.HostGroup{},
+					&dbmodels.ACL{},
+					&dbmodels.Session{},
+					&dbmodels.Event{},
+				)
 			},
 			Rollback: func(tx *gorm.DB) error { return fmt.Errorf("not implemented") },
 		},
@@ -824,6 +845,113 @@ func MigrateToGCMCipher(db *gorm.DB, aesKey string) error {
 		log.Printf("error(MigrateToGCMCipher): %v", err)
 	} else {
 		log.Printf("info: CFB encrypted fields have been re-encrypted with AES-GCM")
+	}
+
+	return nil
+}
+
+func migrateToGormV2(db *gorm.DB) error {
+	migrator := db.Migrator()
+
+	type HostHostGroup struct {
+		HostID      uint `gorm:"primaryKey"`
+		HostGroupID uint `gorm:"primaryKey"`
+	}
+	type UserUserRole struct {
+		UserID     uint `gorm:"primaryKey"`
+		UserRoleID uint `gorm:"primaryKey"`
+	}
+	type UserUserGroup struct {
+		UserID      uint `gorm:"primaryKey"`
+		UserGroupID uint `gorm:"primaryKey"`
+	}
+	type UserGroupACL struct {
+		UserGroupID uint `gorm:"primaryKey"`
+		ACLID       uint `gorm:"primaryKey"`
+	}
+	type HostGroupACL struct {
+		HostGroupID uint `gorm:"primaryKey"`
+		ACLID       uint `gorm:"primaryKey"`
+	}
+
+	joinTables := []struct {
+		model     interface{}
+		fieldName string
+		joinModel interface{}
+	}{
+		{&dbmodels.Host{}, "Groups", &HostHostGroup{}},
+		{&dbmodels.UserRole{}, "Users", &UserUserRole{}},
+		{&dbmodels.UserGroup{}, "Users", &UserUserGroup{}},
+		{&dbmodels.UserGroup{}, "ACLs", &UserGroupACL{}},
+		{&dbmodels.HostGroup{}, "ACLs", &HostGroupACL{}},
+	}
+
+	for _, jt := range joinTables {
+		if err := db.SetupJoinTable(jt.model, jt.fieldName, jt.joinModel); err != nil {
+			return fmt.Errorf("prepareMySQLForV2: setup join table for %T.%s: %w", jt.model, jt.fieldName, err)
+		}
+	}
+
+	alterations := []struct {
+		model  interface{}
+		fields []string
+	}{
+		{&dbmodels.Setting{}, []string{"ID"}},
+		{&dbmodels.SSHKey{}, []string{"ID"}},
+		{&dbmodels.Host{}, []string{"ID", "SSHKeyID", "HopID"}},
+		{&dbmodels.UserKey{}, []string{"ID", "UserID"}},
+		{&dbmodels.UserRole{}, []string{"ID"}},
+		{&dbmodels.User{}, []string{"ID"}},
+		{&dbmodels.UserGroup{}, []string{"ID"}},
+		{&dbmodels.HostGroup{}, []string{"ID"}},
+		{&dbmodels.ACL{}, []string{"ID"}},
+		{&dbmodels.Session{}, []string{"ID", "UserID", "HostID"}},
+		{&dbmodels.Event{}, []string{"ID", "AuthorID"}},
+		{&HostHostGroup{}, []string{"HostID", "HostGroupID"}},
+		{&UserUserRole{}, []string{"UserID", "UserRoleID"}},
+		{&UserUserGroup{}, []string{"UserID", "UserGroupID"}},
+		{&UserGroupACL{}, []string{"UserGroupID", "ACLID"}},
+		{&HostGroupACL{}, []string{"HostGroupID", "ACLID"}},
+	}
+
+	for _, a := range alterations {
+		for _, field := range a.fields {
+			if err := migrator.AlterColumn(a.model, field); err != nil {
+				return fmt.Errorf("alter %T.%s failed: %w", a.model, field, err)
+			}
+		}
+	}
+
+	// Clean up orphaned records before creating foreign keys
+	cleanupStatements := []string{
+		"UPDATE hosts SET hop_id = NULL WHERE hop_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM hosts h2 WHERE h2.id = hosts.hop_id)",
+		"UPDATE hosts SET ssh_key_id = NULL WHERE ssh_key_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM ssh_keys WHERE ssh_keys.id = hosts.ssh_key_id)",
+		"UPDATE sessions SET user_id = NULL WHERE user_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM users WHERE users.id = sessions.user_id)",
+		"UPDATE sessions SET host_id = NULL WHERE host_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM hosts WHERE hosts.id = sessions.host_id)",
+		"UPDATE events SET author_id = NULL WHERE author_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM users WHERE users.id = events.author_id)",
+
+		"DELETE FROM user_keys WHERE NOT EXISTS (SELECT 1 FROM users WHERE users.id = user_keys.user_id)",
+
+		"DELETE FROM host_host_groups WHERE NOT EXISTS (SELECT 1 FROM hosts WHERE hosts.id = host_host_groups.host_id)",
+		"DELETE FROM host_host_groups WHERE NOT EXISTS (SELECT 1 FROM host_groups WHERE host_groups.id = host_host_groups.host_group_id)",
+
+		"DELETE FROM user_user_roles WHERE NOT EXISTS (SELECT 1 FROM users WHERE users.id = user_user_roles.user_id)",
+		"DELETE FROM user_user_roles WHERE NOT EXISTS (SELECT 1 FROM user_roles WHERE user_roles.id = user_user_roles.user_role_id)",
+
+		"DELETE FROM user_user_groups WHERE NOT EXISTS (SELECT 1 FROM users WHERE users.id = user_user_groups.user_id)",
+		"DELETE FROM user_user_groups WHERE NOT EXISTS (SELECT 1 FROM user_groups WHERE user_groups.id = user_user_groups.user_group_id)",
+
+		"DELETE FROM user_group_acls WHERE NOT EXISTS (SELECT 1 FROM user_groups WHERE user_groups.id = user_group_acls.user_group_id)",
+		"DELETE FROM user_group_acls WHERE NOT EXISTS (SELECT 1 FROM acls WHERE acls.id = user_group_acls.acl_id)",
+
+		"DELETE FROM host_group_acls WHERE NOT EXISTS (SELECT 1 FROM host_groups WHERE host_groups.id = host_group_acls.host_group_id)",
+		"DELETE FROM host_group_acls WHERE NOT EXISTS (SELECT 1 FROM acls WHERE acls.id = host_group_acls.acl_id)",
+	}
+
+	for _, stmt := range cleanupStatements {
+		if err := db.Exec(stmt).Error; err != nil {
+			log.Printf("warn: failed to clean orphaned records for mysql: %v", err)
+		}
 	}
 
 	return nil

--- a/pkg/bastion/shell.go
+++ b/pkg/bastion/shell.go
@@ -994,7 +994,7 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 							authKey := ""
 							if host.SSHKeyID > 0 {
 								var key dbmodels.SSHKey
-								if err := db.Model(host).Association("SSHKey").Find(&key); err != nil {
+								if err := db.Model(&host).Association("SSHKey").Find(&key); err != nil {
 									return err
 								}
 								authKey = key.Name
@@ -1006,7 +1006,7 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 							var hop string
 							if host.HopID != 0 {
 								var hopHost dbmodels.Host
-								if err := db.Model(host).Association("Hop").Find(&hopHost); err != nil {
+								if err := db.Model(&host).Association("Hop").Find(&hopHost); err != nil {
 									return err
 								}
 								hop = hopHost.Name
@@ -1099,7 +1099,7 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 
 							// Host key
 							if cmd.Bool("reset") {
-								if err := db.Model(host).Update("HostKey", nil).Error; err != nil {
+								if err := model.Update("HostKey", nil).Error; err != nil {
 									tx.Rollback()
 									return err
 								}
@@ -2008,7 +2008,7 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 
 						tx := db.Begin()
 						for _, user := range users {
-							model := tx.Model(user)
+							model := tx.Model(&user)
 							// simple fields
 							for _, fieldname := range []string{"name", "email", FlagCommentName} {
 								if cmd.String(fieldname) != "" {
@@ -2051,7 +2051,7 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 								return err
 							}
 
-							groups := tx.Model(user).Association("Groups")
+							groups := tx.Model(&user).Association("Groups")
 
 							if err := groups.Append(&appendGroups); err != nil {
 								tx.Rollback()
@@ -2074,7 +2074,7 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 								return err
 							}
 
-							roles := tx.Model(user).Association("Roles")
+							roles := tx.Model(&user).Association("Roles")
 
 							if err := roles.Append(&appendRoles); err != nil {
 								tx.Rollback()

--- a/pkg/bastion/shell.go
+++ b/pkg/bastion/shell.go
@@ -24,6 +24,7 @@ import (
 	"github.com/urfave/cli/v3"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/terminal" // nolint:staticcheck
+	"gorm.io/gorm"
 )
 
 var banner = `
@@ -57,7 +58,11 @@ const (
 	FlagQuietName    = "quiet"
 	FlagInspectName  = "inspect"
 	UserAdminName    = "admin"
+	FlagLimitName    = "limit"
+	FlagLimitUsage   = "Limit the number of item to display (0 for no limit)"
 )
+
+const defaultBatchSize = 3000
 
 func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 	var (
@@ -190,23 +195,37 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{Name: FlagLatestName, Aliases: []string{"l"}, Usage: "Show the latest ACL"},
 						&cli.BoolFlag{Name: FlagQuietName, Aliases: []string{"q"}, Usage: FlagQuietUsage},
+						&cli.IntFlag{Name: FlagLimitName, Aliases: []string{"n"}, Value: 100, Usage: FlagLimitUsage},
 					},
 					Action: func(c context.Context, cmd *cli.Command) error {
 						if err := myself.CheckRoles([]string{UserAdminName}); err != nil {
 							return err
 						}
 
-						var acls []*dbmodels.ACL
-						query := db.Order("created_at desc").Preload("UserGroups").Preload("HostGroups")
+						limit := cmd.Int(FlagLimitName)
+						query := db.Order("id desc").Preload("UserGroups").Preload("HostGroups")
+
+						var acls []dbmodels.ACL
+						var err error
+
 						if cmd.Bool(FlagLatestName) {
 							var acl dbmodels.ACL
 							if err := query.First(&acl).Error; err != nil {
 								return err
 							}
-							acls = append(acls, &acl)
-						} else if err := query.Find(&acls).Error; err != nil {
-							return err
+							acls = append(acls, acl)
+						} else {
+							acls, err = FetchPaginated[dbmodels.ACL](
+								query,
+								limit,
+								defaultBatchSize,
+								func(a dbmodels.ACL) uint { return a.ID },
+							)
+							if err != nil {
+								return err
+							}
 						}
+
 						if cmd.Bool(FlagQuietName) {
 							for _, acl := range acls {
 								fmt.Fprintln(s, acl.ID)
@@ -692,22 +711,35 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{Name: FlagLatestName, Aliases: []string{"l"}, Usage: "Show the latest event"},
 						&cli.BoolFlag{Name: FlagQuietName, Aliases: []string{"q"}, Usage: FlagQuietUsage},
+						&cli.IntFlag{Name: FlagLimitName, Aliases: []string{"n"}, Value: 100, Usage: FlagLimitUsage},
 					},
 					Action: func(c context.Context, cmd *cli.Command) error {
 						if err := myself.CheckRoles([]string{UserAdminName}); err != nil {
 							return err
 						}
 
+						limit := cmd.Int(FlagLimitName)
+						query := db.Order("id desc").Preload("Author")
+
 						var events []dbmodels.Event
-						query := db.Order("created_at desc").Preload("Author")
+						var err error
+
 						if cmd.Bool(FlagLatestName) {
 							var event dbmodels.Event
 							if err := query.First(&event).Error; err != nil {
 								return err
 							}
 							events = append(events, event)
-						} else if err := query.Find(&events).Error; err != nil {
-							return err
+						} else {
+							events, err = FetchPaginated[dbmodels.Event](
+								query,
+								limit,
+								defaultBatchSize,
+								func(a dbmodels.Event) uint { return a.ID },
+							)
+							if err != nil {
+								return err
+							}
 						}
 
 						if cmd.Bool(FlagQuietName) {
@@ -898,22 +930,35 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{Name: FlagLatestName, Aliases: []string{"l"}, Usage: "Show the latest host"},
 						&cli.BoolFlag{Name: FlagQuietName, Aliases: []string{"q"}, Usage: FlagQuietUsage},
+						&cli.IntFlag{Name: FlagLimitName, Aliases: []string{"n"}, Value: 100, Usage: FlagLimitUsage},
 					},
 					Action: func(c context.Context, cmd *cli.Command) error {
 						if err := myself.CheckRoles([]string{"admin", "listhosts"}); err != nil {
 							return err
 						}
 
-						var hosts []*dbmodels.Host
-						query := db.Order("created_at desc").Preload("Groups")
+						limit := cmd.Int(FlagLimitName)
+						query := db.Order("id desc").Preload("Groups")
+
+						var hosts []dbmodels.Host
+						var err error
+
 						if cmd.Bool(FlagLatestName) {
 							var host dbmodels.Host
 							if err := query.First(&host).Error; err != nil {
 								return err
 							}
-							hosts = append(hosts, &host)
-						} else if err := query.Find(&hosts).Error; err != nil {
-							return err
+							hosts = append(hosts, host)
+						} else {
+							hosts, err = FetchPaginated[dbmodels.Host](
+								query,
+								limit,
+								defaultBatchSize,
+								func(a dbmodels.Host) uint { return a.ID },
+							)
+							if err != nil {
+								return err
+							}
 						}
 
 						if cmd.Bool(FlagQuietName) {
@@ -1210,22 +1255,34 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{Name: FlagLatestName, Aliases: []string{"l"}, Usage: "Show the latest host group"},
 						&cli.BoolFlag{Name: FlagQuietName, Aliases: []string{"q"}, Usage: FlagQuietUsage},
+						&cli.IntFlag{Name: FlagLimitName, Aliases: []string{"n"}, Value: 100, Usage: FlagLimitUsage},
 					},
 					Action: func(c context.Context, cmd *cli.Command) error {
 						if err := myself.CheckRoles([]string{UserAdminName}); err != nil {
 							return err
 						}
+						limit := cmd.Int(FlagLimitName)
+						query := db.Order("id desc")
 
-						var hostGroups []*dbmodels.HostGroup
-						query := db.Order("created_at desc").Preload("ACLs").Preload("Hosts")
+						var hostGroups []dbmodels.HostGroup
+						var err error
+
 						if cmd.Bool(FlagLatestName) {
 							var hostGroup dbmodels.HostGroup
 							if err := query.First(&hostGroup).Error; err != nil {
 								return err
 							}
-							hostGroups = append(hostGroups, &hostGroup)
-						} else if err := query.Find(&hostGroups).Error; err != nil {
-							return err
+							hostGroups = append(hostGroups, hostGroup)
+						} else {
+							hostGroups, err = FetchPaginated[dbmodels.HostGroup](
+								query,
+								limit,
+								defaultBatchSize,
+								func(a dbmodels.HostGroup) uint { return a.ID },
+							)
+							if err != nil {
+								return err
+							}
 						}
 
 						if cmd.Bool(FlagQuietName) {
@@ -1248,11 +1305,13 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 						})
 						for _, hostGroup := range hostGroups {
 							// FIXME: add more stats (amount of hosts, linked usergroups, ...)
+							hostsCount := db.Model(hostGroup).Association("Hosts").Count()
+							aclsCount := db.Model(hostGroup).Association("ACLs").Count()
 							if err := table.Append(
 								fmt.Sprintf("%d", hostGroup.ID),
 								hostGroup.Name,
-								fmt.Sprintf("%d", len(hostGroup.Hosts)),
-								fmt.Sprintf("%d", len(hostGroup.ACLs)),
+								fmt.Sprintf("%d", hostsCount),
+								fmt.Sprintf("%d", aclsCount),
 								utils.Time(hostGroup.UpdatedAt),
 								utils.Time(hostGroup.CreatedAt),
 								hostGroup.Comment,
@@ -1527,23 +1586,37 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{Name: FlagLatestName, Aliases: []string{"l"}, Usage: "Show the latest key"},
 						&cli.BoolFlag{Name: FlagQuietName, Aliases: []string{"q"}, Usage: FlagQuietUsage},
+						&cli.IntFlag{Name: FlagLimitName, Aliases: []string{"n"}, Value: 100, Usage: FlagLimitUsage},
 					},
 					Action: func(c context.Context, cmd *cli.Command) error {
 						if err := myself.CheckRoles([]string{UserAdminName}); err != nil {
 							return err
 						}
 
-						var sshKeys []*dbmodels.SSHKey
-						query := db.Order("created_at desc").Preload("Hosts")
+						limit := cmd.Int(FlagLimitName)
+						query := db.Order("id desc").Preload("Hosts")
+
+						var sshKeys []dbmodels.SSHKey
+						var err error
+
 						if cmd.Bool(FlagLatestName) {
 							var sshKey dbmodels.SSHKey
 							if err := query.First(&sshKey).Error; err != nil {
 								return err
 							}
-							sshKeys = append(sshKeys, &sshKey)
-						} else if err := query.Find(&sshKeys).Error; err != nil {
-							return err
+							sshKeys = append(sshKeys, sshKey)
+						} else {
+							sshKeys, err = FetchPaginated[dbmodels.SSHKey](
+								query,
+								limit,
+								defaultBatchSize,
+								func(a dbmodels.SSHKey) uint { return a.ID },
+							)
+							if err != nil {
+								return err
+							}
 						}
+
 						if cmd.Bool(FlagQuietName) {
 							for _, sshKey := range sshKeys {
 								fmt.Fprintln(s, sshKey.ID)
@@ -1792,23 +1865,37 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{Name: FlagLatestName, Aliases: []string{"l"}, Usage: "Show the latest user"},
 						&cli.BoolFlag{Name: FlagQuietName, Aliases: []string{"q"}, Usage: FlagQuietUsage},
+						&cli.IntFlag{Name: FlagLimitName, Aliases: []string{"n"}, Value: 100, Usage: FlagLimitUsage},
 					},
 					Action: func(c context.Context, cmd *cli.Command) error {
 						if err := myself.CheckRoles([]string{UserAdminName}); err != nil {
 							return err
 						}
 
-						var users []*dbmodels.User
-						query := db.Order("created_at desc").Preload("Groups").Preload("Roles").Preload("Keys")
+						limit := cmd.Int(FlagLimitName)
+						query := db.Order("id desc").Preload("Roles").Preload("Keys")
+
+						var users []dbmodels.User
+						var err error
+
 						if cmd.Bool(FlagLatestName) {
 							var user dbmodels.User
 							if err := query.First(&user).Error; err != nil {
 								return err
 							}
-							users = append(users, &user)
-						} else if err := query.Find(&users).Error; err != nil {
-							return err
+							users = append(users, user)
+						} else {
+							users, err = FetchPaginated[dbmodels.User](
+								query,
+								limit,
+								defaultBatchSize,
+								func(a dbmodels.User) uint { return a.ID },
+							)
+							if err != nil {
+								return err
+							}
 						}
+
 						if cmd.Bool(FlagQuietName) {
 							for _, user := range users {
 								fmt.Fprintln(s, user.ID)
@@ -1906,7 +1993,7 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 						}
 
 						// FIXME: check if unset-admin + user == myself
-						var users []*dbmodels.User
+						var users []dbmodels.User
 						if err := dbmodels.UsersByIdentifiers(db, cmd.Args().Slice()).Find(&users).Error; err != nil {
 							return err
 						}
@@ -2070,23 +2157,37 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{Name: FlagLatestName, Aliases: []string{"l"}, Usage: "Show the latest user group"},
 						&cli.BoolFlag{Name: FlagQuietName, Aliases: []string{"q"}, Usage: FlagQuietUsage},
+						&cli.IntFlag{Name: FlagLimitName, Aliases: []string{"n"}, Value: 100, Usage: FlagLimitUsage},
 					},
 					Action: func(c context.Context, cmd *cli.Command) error {
 						if err := myself.CheckRoles([]string{UserAdminName}); err != nil {
 							return err
 						}
 
-						var userGroups []*dbmodels.UserGroup
-						query := db.Order("created_at desc").Preload("ACLs").Preload("Users")
+						limit := cmd.Int(FlagLimitName)
+						query := db.Order("id desc")
+
+						var userGroups []dbmodels.UserGroup
+						var err error
+
 						if cmd.Bool(FlagLatestName) {
 							var userGroup dbmodels.UserGroup
 							if err := query.First(&userGroup).Error; err != nil {
 								return err
 							}
-							userGroups = append(userGroups, &userGroup)
-						} else if err := query.Find(&userGroups).Error; err != nil {
-							return err
+							userGroups = append(userGroups, userGroup)
+						} else {
+							userGroups, err = FetchPaginated[dbmodels.UserGroup](
+								query,
+								limit,
+								defaultBatchSize,
+								func(a dbmodels.UserGroup) uint { return a.ID },
+							)
+							if err != nil {
+								return err
+							}
 						}
+
 						if cmd.Bool(FlagQuietName) {
 							for _, userGroup := range userGroups {
 								fmt.Fprintln(s, userGroup.ID)
@@ -2106,11 +2207,13 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 							Align: tw.AlignCenter,
 						})
 						for _, userGroup := range userGroups {
+							usersCount := db.Model(userGroup).Association("Users").Count()
+							aclsCount := db.Model(userGroup).Association("ACLs").Count()
 							if err := table.Append(
 								fmt.Sprintf("%d", userGroup.ID),
 								userGroup.Name,
-								fmt.Sprintf("%d", len(userGroup.Users)),
-								fmt.Sprintf("%d", len(userGroup.ACLs)),
+								fmt.Sprintf("%d", usersCount),
+								fmt.Sprintf("%d", aclsCount),
 								utils.Time(userGroup.UpdatedAt),
 								utils.Time(userGroup.CreatedAt),
 								userGroup.Comment,
@@ -2289,23 +2392,37 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 					Flags: []cli.Flag{
 						&cli.BoolFlag{Name: FlagLatestName, Aliases: []string{"l"}, Usage: "Show the latest user key"},
 						&cli.BoolFlag{Name: FlagQuietName, Aliases: []string{"q"}, Usage: FlagQuietUsage},
+						&cli.IntFlag{Name: FlagLimitName, Aliases: []string{"n"}, Value: 100, Usage: FlagLimitUsage},
 					},
 					Action: func(c context.Context, cmd *cli.Command) error {
 						if err := myself.CheckRoles([]string{UserAdminName}); err != nil {
 							return err
 						}
 
-						var userKeys []*dbmodels.UserKey
-						query := db.Order("created_at desc").Preload("User")
+						limit := cmd.Int(FlagLimitName)
+						query := db.Order("id desc")
+
+						var userKeys []dbmodels.UserKey
+						var err error
+
 						if cmd.Bool(FlagLatestName) {
 							var userKey dbmodels.UserKey
 							if err := query.First(&userKey).Error; err != nil {
 								return err
 							}
-							userKeys = append(userKeys, &userKey)
-						} else if err := query.Find(&userKeys).Error; err != nil {
-							return err
+							userKeys = append(userKeys, userKey)
+						} else {
+							userKeys, err = FetchPaginated[dbmodels.UserKey](
+								query,
+								limit,
+								defaultBatchSize,
+								func(a dbmodels.UserKey) uint { return a.ID },
+							)
+							if err != nil {
+								return err
+							}
 						}
+
 						if cmd.Bool(FlagQuietName) {
 							for _, userKey := range userKeys {
 								fmt.Fprintln(s, userKey.ID)
@@ -2411,45 +2528,42 @@ func shell(s gliderssh.Session, version, gitSha, gitTag string) error {
 						&cli.BoolFlag{Name: FlagLatestName, Aliases: []string{"l"}, Usage: "Show the latest session"},
 						&cli.BoolFlag{Name: "active", Aliases: []string{"a"}, Usage: "Show only active session"},
 						&cli.BoolFlag{Name: FlagQuietName, Aliases: []string{"q"}, Usage: FlagQuietUsage},
+						&cli.IntFlag{Name: FlagLimitName, Aliases: []string{"n"}, Value: 100, Usage: FlagLimitUsage},
 					},
 					Action: func(c context.Context, cmd *cli.Command) error {
 						if err := myself.CheckRoles([]string{UserAdminName}); err != nil {
 							return err
 						}
 
-						var sessions []*dbmodels.Session
+						limit := cmd.Int(FlagLimitName)
+						status := []string{string(dbmodels.SessionStatusActive), string(dbmodels.SessionStatusClosed), string(dbmodels.SessionStatusUnknown)}
 
-						limit, offset, status := 60000, -1, []string{string(dbmodels.SessionStatusActive), string(dbmodels.SessionStatusClosed), string(dbmodels.SessionStatusUnknown)}
 						if cmd.Bool("active") {
 							status = status[:1]
 						}
+						query := db.Order("id desc").Where("status in (?)", status).Preload("User").Preload("Host")
 
-						query := db.Order("created_at desc").Limit(limit).Offset(offset).Where("status in (?)", status).Preload("User").Preload("Host")
+						var sessions []dbmodels.Session
+						var err error
 
 						if cmd.Bool(FlagLatestName) {
 							var session dbmodels.Session
 							if err := query.First(&session).Error; err != nil {
 								return err
 							}
-							sessions = append(sessions, &session)
+							sessions = append(sessions, session)
 						} else {
-							if err := query.Find(&sessions).Error; err != nil {
+							sessions, err = FetchPaginated[dbmodels.Session](
+								query,
+								limit,
+								defaultBatchSize,
+								func(a dbmodels.Session) uint { return a.ID },
+							)
+							if err != nil {
 								return err
 							}
-
-							factor := 1
-							for len(sessions) >= limit*factor {
-								var additionnalSessions []*dbmodels.Session
-
-								offset = limit * factor
-								query := db.Order("created_at desc").Limit(limit).Offset(offset).Where("status in (?)", status).Preload("User").Preload("Host")
-								if err := query.Find(&additionnalSessions).Error; err != nil {
-									return err
-								}
-								sessions = append(sessions, additionnalSessions...)
-								factor++
-							}
 						}
+
 						if cmd.Bool(FlagQuietName) {
 							for _, session := range sessions {
 								fmt.Fprintln(s, session.ID)
@@ -2590,4 +2704,51 @@ func parseOptionalTime(input string) (*time.Time, error) {
 		return &parsed, nil
 	}
 	return nil, nil
+}
+
+// FetchPaginated retrieves records in batches, using cursor-based
+// pagination on the ID (avoids costly OFFSETs on large tables).
+// limit == 0 will fetch all data (with batchSize).
+// limit > 0 will stop as soon as `limit` results are fetched.
+func FetchPaginated[T any](
+	queryBuilder *gorm.DB,
+	limit int,
+	batchSize int,
+	getID func(T) uint,
+) ([]T, error) {
+
+	var results []T
+	var lastID uint = 0
+
+	for limit == 0 || len(results) < limit {
+		fetchSize := batchSize
+
+		if limit > 0 {
+			if remaining := limit - len(results); remaining < fetchSize {
+				fetchSize = remaining
+			}
+		}
+
+		var batch []T
+		query := queryBuilder.Limit(fetchSize)
+		if lastID != 0 {
+			query = query.Where("id < ?", lastID)
+		}
+		if err := query.Find(&batch).Error; err != nil {
+			return nil, err
+		}
+
+		if len(batch) == 0 {
+			break
+		}
+
+		results = append(results, batch...)
+		lastID = getID(batch[len(batch)-1])
+
+		if len(batch) < fetchSize {
+			break
+		}
+	}
+
+	return results, nil
 }

--- a/pkg/dbmodels/dbmodels.go
+++ b/pkg/dbmodels/dbmodels.go
@@ -44,7 +44,7 @@ type SSHKey struct {
 	Fingerprint string  `valid:"optional"`
 	PrivKey     string  `sql:"size:5000" valid:"required"`
 	PubKey      string  `sql:"size:1000" valid:"optional"`
-	Hosts       []*Host `gorm:"ForeignKey:SSHKeyID"`
+	Hosts       []*Host `gorm:"ForeignKey:SSHKeyID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
 	Comment     string  `valid:"optional"`
 }
 
@@ -56,14 +56,14 @@ type Host struct {
 	User     string       `valid:"optional"` // FIXME: to be removed in a future version in favor of URL
 	Password string       `valid:"optional"` // FIXME: to be removed in a future version in favor of URL
 	URL      string       `valid:"optional"`
-	SSHKey   *SSHKey      `gorm:"ForeignKey:SSHKeyID"` // SSHKey used to connect by the client
-	SSHKeyID uint         `gorm:"index"`
+	SSHKey   *SSHKey      `gorm:"ForeignKey:SSHKeyID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"` // SSHKey used to connect by the client
+	SSHKeyID uint         `gorm:"index;default:NULL"`
 	HostKey  []byte       `sql:"size:1000" valid:"optional"`
-	Groups   []*HostGroup `gorm:"many2many:host_host_groups;"`
+	Groups   []*HostGroup `gorm:"many2many:host_host_groups;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Comment  string       `valid:"optional"`
 	Logging  string       `valid:"optional,host_logging_mode"`
-	Hop      *Host
-	HopID    uint
+	Hop      *Host        `gorm:"ForeignKey:HopID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+	HopID    uint         `gorm:"default:NULL"`
 }
 
 // UserKey defines a user public key used by sshportal to identify the user
@@ -72,24 +72,24 @@ type UserKey struct {
 	Key           []byte `sql:"size:1000" valid:"length(1|1000)"`
 	AuthorizedKey string `sql:"size:1000" valid:"required,length(1|1000)"`
 	UserID        uint   ``
-	User          *User  `gorm:"ForeignKey:UserID"`
+	User          *User  `gorm:"ForeignKey:UserID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Comment       string `valid:"optional"`
 }
 
 type UserRole struct {
 	gorm.Model
 	Name  string  `valid:"required,length(1|255),unix_user"`
-	Users []*User `gorm:"many2many:user_user_roles"`
+	Users []*User `gorm:"many2many:user_user_roles;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 }
 
 type User struct {
 	// FIXME: use uuid for ID
 	gorm.Model
-	Roles       []*UserRole  `gorm:"many2many:user_user_roles"`
+	Roles       []*UserRole  `gorm:"many2many:user_user_roles;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Email       string       `valid:"required,email"`
 	Name        string       `valid:"required,length(1|255),unix_user" gorm:"index:uix_users_name,unique"`
-	Keys        []*UserKey   `gorm:"ForeignKey:UserID"`
-	Groups      []*UserGroup `gorm:"many2many:user_user_groups;"`
+	Keys        []*UserKey   `gorm:"ForeignKey:UserID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	Groups      []*UserGroup `gorm:"many2many:user_user_groups;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Comment     string       `valid:"optional"`
 	InviteToken string       `valid:"optional,length(10|60)"`
 }
@@ -97,23 +97,23 @@ type User struct {
 type UserGroup struct {
 	gorm.Model
 	Name    string  `valid:"required,length(1|255),unix_user" gorm:"index:uix_usergroups_name,unique"`
-	Users   []*User `gorm:"many2many:user_user_groups;"`
-	ACLs    []*ACL  `gorm:"many2many:user_group_acls;"`
+	Users   []*User `gorm:"many2many:user_user_groups;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	ACLs    []*ACL  `gorm:"many2many:user_group_acls;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Comment string  `valid:"optional"`
 }
 
 type HostGroup struct {
 	gorm.Model
 	Name    string  `valid:"required,length(1|255),unix_user" gorm:"index:uix_hostgroups_name,unique"`
-	Hosts   []*Host `gorm:"many2many:host_host_groups;"`
-	ACLs    []*ACL  `gorm:"many2many:host_group_acls;"`
+	Hosts   []*Host `gorm:"many2many:host_host_groups;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	ACLs    []*ACL  `gorm:"many2many:host_group_acls;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	Comment string  `valid:"optional"`
 }
 
 type ACL struct {
 	gorm.Model
-	HostGroups  []*HostGroup `gorm:"many2many:host_group_acls;"`
-	UserGroups  []*UserGroup `gorm:"many2many:user_group_acls;"`
+	HostGroups  []*HostGroup `gorm:"many2many:host_group_acls;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
+	UserGroups  []*UserGroup `gorm:"many2many:user_group_acls;constraint:OnUpdate:CASCADE,OnDelete:CASCADE;"`
 	HostPattern string       `valid:"optional"`
 	Action      string       `valid:"required"`
 	Weight      uint         ``
@@ -126,18 +126,18 @@ type Session struct {
 	gorm.Model
 	StoppedAt *time.Time `sql:"index" valid:"optional"`
 	Status    string     `valid:"required"`
-	User      *User      `gorm:"ForeignKey:UserID"`
-	Host      *Host      `gorm:"ForeignKey:HostID"`
-	UserID    uint       `valid:"optional"`
-	HostID    uint       `valid:"optional"`
+	User      *User      `gorm:"ForeignKey:UserID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+	Host      *Host      `gorm:"ForeignKey:HostID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+	UserID    uint       `valid:"optional" gorm:"default:NULL"`
+	HostID    uint       `valid:"optional" gorm:"default:NULL"`
 	ErrMsg    string     `valid:"optional"`
 	Comment   string     `valid:"optional"`
 }
 
 type Event struct {
 	gorm.Model
-	Author   *User                  `gorm:"ForeignKey:AuthorID"`
-	AuthorID uint                   `valid:"optional"`
+	Author   *User                  `gorm:"ForeignKey:AuthorID;constraint:OnUpdate:CASCADE,OnDelete:SET NULL;"`
+	AuthorID uint                   `valid:"optional" gorm:"default:NULL"`
 	Domain   string                 `valid:"required"`
 	Action   string                 `valid:"required"`
 	Entity   string                 `valid:"optional"`

--- a/server.go
+++ b/server.go
@@ -85,8 +85,7 @@ func server(c *serverConfig) (err error) {
 	// configure db logging
 
 	db, _ := dbConnect(c, &gorm.Config{
-		DisableForeignKeyConstraintWhenMigrating: true,
-		Logger:                                   logger.Default.LogMode(logger.Silent),
+		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	sqlDB, err := db.DB()
 


### PR DESCRIPTION
- ensure we don't preload huge amount of data or use huge prepared statements in `ls` commands
- add a --limit option to the `session ls` command (default: 1000)
- use indexed IDs instead of non-indexed dates where we can
- makes sur to cascade delete when needed (+ automigrate added)

This fix the following error on some "ls" commands;

> error: Error 1390 (HY000): Prepared statement contains too many placeholders